### PR TITLE
Annotate SNV SHAP with RGI metadata and parallelize test build

### DIFF
--- a/StrainAMR_build_train.py
+++ b/StrainAMR_build_train.py
@@ -444,7 +444,8 @@ def run(ingenome,label,odir,drug,pc_c,snv_c,kmer_c,mfile,threads=1):
     shap_feature_select_withcls.shap_select(
         work_dir+'/strains_train_sentence_fs.txt',
         shap_dir+'/strains_train_sentence_fs_shap_filter.txt',
-        [work_dir+'/node_token_match.txt']
+        [work_dir+'/node_token_match.txt'],
+        rgi_dir=work_dir+'/rgi_train'
     )
     shap_feature_select_withcls.shap_select(
         work_dir+'/strains_train_pc_token_fs.txt',

--- a/StrainAMR_model_predict.py
+++ b/StrainAMR_model_predict.py
@@ -423,7 +423,8 @@ def main():
                 pc_file, pc_shap, [os.path.join(indir, 'pc_matches.txt')]
             )
             shap_feature_select_withcls.shap_select(
-                snv_file, snv_shap, [os.path.join(indir, 'node_token_match.txt')]
+                snv_file, snv_shap, [os.path.join(indir, 'node_token_match.txt')],
+                rgi_dir=os.path.join(indir, 'rgi_train')
             )
             shap_feature_select_withcls.shap_select(
                 kmer_file, kmer_shap, [os.path.join(indir, 'kmer_token_id.txt')]
@@ -448,6 +449,7 @@ def main():
                 snv_shap,
                 pair_snv,
                 [os.path.join(indir, 'node_token_match.txt')],
+                rgi_dir=os.path.join(indir, 'rgi_train')
             )
             analyze_attention_matrix_network_optimize_iterate_shap.obtain_important_tokens(
                 test_at3,

--- a/StrainAMR_model_train.py
+++ b/StrainAMR_model_train.py
@@ -639,7 +639,8 @@ def main():
                 'graph_train',
                 indir + '/strains_train_sentence_fs_shap.txt',
                 pair_snv,
-                [indir + '/node_token_match.txt']
+                [indir + '/node_token_match.txt'],
+                rgi_dir=os.path.join(indir, 'rgi_train')
             )
 
         if fused=='kmer':
@@ -670,7 +671,8 @@ def main():
                 'graph_train',
                 indir + '/strains_train_sentence_fs_shap.txt',
                 pair_snv,
-                [indir + '/node_token_match.txt']
+                [indir + '/node_token_match.txt'],
+                rgi_dir=os.path.join(indir, 'rgi_train')
             )
             analyze_attention_matrix_network_optimize_iterate_shap.obtain_important_tokens(
                 train_at3,
@@ -698,7 +700,8 @@ def main():
             'graph_train',
             indir + '/strains_train_sentence_fs_shap.txt',
             pair_snv,
-            [indir + '/node_token_match.txt']
+            [indir + '/node_token_match.txt'],
+            rgi_dir=os.path.join(indir, 'rgi_train')
         )
         analyze_attention_matrix_network_optimize_iterate_shap.obtain_important_tokens(
             train_at3,
@@ -726,7 +729,8 @@ def main():
                 'graph_test',
                 indir + '/strains_train_sentence_fs_shap.txt',
                 pair_snv,
-                [indir + '/node_token_match.txt']
+                [indir + '/node_token_match.txt'],
+                rgi_dir=os.path.join(indir, 'rgi_train')
             )
             analyze_attention_matrix_network_optimize_iterate_shap.obtain_important_tokens(
                 test_at3,

--- a/library/shap_feature_select_withcls.py
+++ b/library/shap_feature_select_withcls.py
@@ -94,12 +94,13 @@ def regenerate(infile,ofile,arrs):
     return td
             
 
-def shap_select(infile, ofile, mapping_files=None):
-    """Run SHAP on tokens and write a table with feature names."""
+def shap_select(infile, ofile, mapping_files=None, rgi_dir=None):
+    """Run SHAP on tokens and write a table with feature names and optional RGI info."""
     based = os.path.dirname(ofile)
     pre = os.path.splitext(os.path.basename(infile))[0]
     X, y, feas, strains = convert2arr(infile)
     map_dict = utils.load_token_mappings(mapping_files)
+    rgi_map = utils.load_rgi_annotations(rgi_dir)
     nX=pd.DataFrame(data = X,columns=feas,index=strains)
     #X_test,y_test,w=convert2arr(intest)
     clf = RandomForestClassifier(random_state=0,n_estimators=500)
@@ -185,18 +186,28 @@ def shap_select(infile, ofile, mapping_files=None):
     res = sorted(d.items(), key=lambda x: x[1], reverse=True)
     c = 0
     o = open(based + '/' + pre + '_shap.txt', 'w+')
+    extra = ''
+    if rgi_map:
+        extra = '\tAMR_Gene_Family\tSNPs_in_Best_Hit_ARO'
     if len(shap_values) == 2:
-        o.write('ID\tToken_ID\tFeature\tShap_0\tShap_1\n')
+        o.write('ID\tToken_ID\tFeature' + extra + '\tShap_0\tShap_1\n')
     else:
-        o.write('ID\tToken_ID\tFeature\tShap\n')
+        o.write('ID\tToken_ID\tFeature' + extra + '\tShap\n')
     for r in res:
         if r[1] == 0:
             continue
         feat_name = utils.token_to_feature(r[0], map_dict)
+        amr, snp = rgi_map.get(feat_name, ('NA', 'NA')) if rgi_map else ('NA', 'NA')
         if len(shap_values) == 2:
-            o.write(f"{c + 1}\t{r[0]}\t{feat_name}\t{r[1]}\t{ds0[r[0]]}\n")
+            if rgi_map:
+                o.write(f"{c + 1}\t{r[0]}\t{feat_name}\t{amr}\t{snp}\t{r[1]}\t{ds0[r[0]]}\n")
+            else:
+                o.write(f"{c + 1}\t{r[0]}\t{feat_name}\t{r[1]}\t{ds0[r[0]]}\n")
         else:
-            o.write(f"{c + 1}\t{r[0]}\t{feat_name}\t{r[1]}\n")
+            if rgi_map:
+                o.write(f"{c + 1}\t{r[0]}\t{feat_name}\t{amr}\t{snp}\t{r[1]}\n")
+            else:
+                o.write(f"{c + 1}\t{r[0]}\t{feat_name}\t{r[1]}\n")
         c += 1
 
     td = regenerate(infile, ofile, arrs)

--- a/library/utils.py
+++ b/library/utils.py
@@ -29,3 +29,32 @@ def load_token_mappings(files):
 def token_to_feature(token_id, mapping):
     """Return human readable feature for token_id if available."""
     return mapping.get(str(token_id), str(token_id))
+
+
+def load_rgi_annotations(rgi_dir):
+    """Parse RGI tabular outputs and map ARO IDs to (AMR Gene Family, SNPs)."""
+    info = {}
+    if not rgi_dir or not os.path.isdir(rgi_dir):
+        return info
+    for fname in os.listdir(rgi_dir):
+        if not fname.endswith('.txt'):
+            continue
+        path = os.path.join(rgi_dir, fname)
+        with open(path, 'r') as f:
+            header = f.readline().strip().split('\t')
+            header = [h.replace(' ', '_') for h in header]
+            idx = {h: i for i, h in enumerate(header)}
+            aro_i = idx.get('Best_Hit_ARO') or idx.get('ARO')
+            if aro_i is None:
+                continue
+            gf_i = idx.get('AMR_Gene_Family')
+            snp_i = idx.get('SNPs_in_Best_Hit_ARO')
+            for line in f:
+                parts = line.strip().split('\t')
+                if len(parts) <= aro_i:
+                    continue
+                aro = parts[aro_i]
+                gf = parts[gf_i] if gf_i is not None and gf_i < len(parts) else 'NA'
+                snp = parts[snp_i] if snp_i is not None and snp_i < len(parts) else 'NA'
+                info[aro] = (gf, snp)
+    return info


### PR DESCRIPTION
## Summary
- Run Prodigal/RGI in parallel in the test build script with a new `--threads` option.
- Parse `rgi_train` outputs to map ARO IDs to AMR gene family and SNP annotations.
- Augment SNV SHAP tables and attention-token reports with these RGI annotations.
- Store SHAP feature files for test data in a dedicated `shap` directory and measure their lengths consistently with training.

## Testing
- `python -m py_compile library/analyze_attention_matrix_network_optimize_iterate_shap.py StrainAMR_build_test.py StrainAMR_model_train.py StrainAMR_model_predict.py library/shap_feature_select_withcls.py library/utils.py StrainAMR_build_train.py`

------
https://chatgpt.com/codex/tasks/task_e_689e234637748333865c26c4a31d9e4f