### PR TITLE
Annotate SNV SHAP with RGI gene families and parallelize test build

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ StrainAMR is a learning-based framework for predicting antimicrobial resistance 
 - **Biologically interpretable feature discovery** using attention weights and SHAP interaction values
 - **Parallel genome processing** with configurable thread count
 - **Token-to-feature mapping** to translate model inputs back to genes, k‑mers and SNVs
+- **RGI-informed SNV annotation** providing AMR gene family context in SHAP outputs
 
 ## Installation (Linux/Ubuntu)
 
@@ -93,6 +94,19 @@ sh batch_train_3fold_exp.sh
 | `-t`, `--threads` | `1` | Number of parallel worker processes |
 | `-o`, `--outdir` | `StrainAMR_res` | Output directory for generated features |
 
+### `StrainAMR_build_test.py`
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `-i`, `--input_file` | required | Directory containing test genome FASTA files |
+| `-l`, `--label_file` | required | Path to phenotype label file for the test data |
+| `-d`, `--drug` | required | Drug name to model; must match training data |
+| `-p`, `--pc` | `0` | Skip protein-cluster token generation when set to `1` |
+| `-s`, `--snv` | `0` | Skip SNV token generation when set to `1` |
+| `-k`, `--kmer` | `0` | Skip k-mer token generation when set to `1` |
+| `-t`, `--threads` | `1` | Number of parallel worker processes |
+| `-o`, `--outdir` | required | Output directory; should match training output directory |
+
 ### `StrainAMR_model_train.py`
 
 | Flag | Default | Description |
@@ -116,10 +130,10 @@ sh batch_train_3fold_exp.sh
 ## Output
 
 - **Feature extraction** (`StrainAMR_build_train.py` / `StrainAMR_build_test.py`)
-  - Token files such as `strains_*_sentence_fs.txt`, `strains_*_pc_token_fs.txt`, `strains_*_kmer_token.txt`
-  - Mapping files (`node_token_match.txt`, `kmer_token_id.txt`) linking token IDs to genomic features
-  - SHAP-filtered feature lists (`*_shap_filter.txt`)
-  - `shap/` – SHAP value tables with token IDs mapped to genes or SNV positions
+    - Token files such as `strains_*_sentence_fs.txt`, `strains_*_pc_token_fs.txt`, `strains_*_kmer_token.txt`
+    - Mapping files (`node_token_match.txt`, `kmer_token_id.txt`) linking token IDs to genomic features
+    - SHAP-filtered feature lists (`*_shap_filter.txt`)
+    - `shap/` – SHAP value tables with token IDs mapped to genes or SNV positions, including AMR gene family annotations for SNV features
 - **Model training** (`StrainAMR_model_train.py`)
   - Results are grouped into subfolders within the specified `--outdir`
     - `models/` – checkpoints such as `best_model_f1_score.pt`
@@ -134,8 +148,9 @@ sh batch_train_3fold_exp.sh
 
 ## New Features
 
-- `StrainAMR_build_train.py` accepts `--threads` to process genomes in parallel
+- `StrainAMR_build_train.py` and `StrainAMR_build_test.py` accept `--threads` to process genomes in parallel
 - Model training computes SHAP interaction values and maps token IDs back to genomic features for improved interpretability
+- SNV SHAP tables and attention-token reports include AMR gene family annotations derived from RGI outputs
 
 ## Citation
 

--- a/StrainAMR_build_train.py
+++ b/StrainAMR_build_train.py
@@ -444,7 +444,8 @@ def run(ingenome,label,odir,drug,pc_c,snv_c,kmer_c,mfile,threads=1):
     shap_feature_select_withcls.shap_select(
         work_dir+'/strains_train_sentence_fs.txt',
         shap_dir+'/strains_train_sentence_fs_shap_filter.txt',
-        [work_dir+'/node_token_match.txt']
+        [work_dir+'/node_token_match.txt'],
+        rgi_dir=work_dir+'/rgi_train'
     )
     shap_feature_select_withcls.shap_select(
         work_dir+'/strains_train_pc_token_fs.txt',

--- a/StrainAMR_model_predict.py
+++ b/StrainAMR_model_predict.py
@@ -423,7 +423,8 @@ def main():
                 pc_file, pc_shap, [os.path.join(indir, 'pc_matches.txt')]
             )
             shap_feature_select_withcls.shap_select(
-                snv_file, snv_shap, [os.path.join(indir, 'node_token_match.txt')]
+                snv_file, snv_shap, [os.path.join(indir, 'node_token_match.txt')],
+                rgi_dir=os.path.join(indir, 'rgi_train')
             )
             shap_feature_select_withcls.shap_select(
                 kmer_file, kmer_shap, [os.path.join(indir, 'kmer_token_id.txt')]
@@ -448,6 +449,7 @@ def main():
                 snv_shap,
                 pair_snv,
                 [os.path.join(indir, 'node_token_match.txt')],
+                rgi_dir=os.path.join(indir, 'rgi_train')
             )
             analyze_attention_matrix_network_optimize_iterate_shap.obtain_important_tokens(
                 test_at3,

--- a/StrainAMR_model_train.py
+++ b/StrainAMR_model_train.py
@@ -639,7 +639,8 @@ def main():
                 'graph_train',
                 indir + '/strains_train_sentence_fs_shap.txt',
                 pair_snv,
-                [indir + '/node_token_match.txt']
+                [indir + '/node_token_match.txt'],
+                rgi_dir=os.path.join(indir, 'rgi_train')
             )
 
         if fused=='kmer':
@@ -670,7 +671,8 @@ def main():
                 'graph_train',
                 indir + '/strains_train_sentence_fs_shap.txt',
                 pair_snv,
-                [indir + '/node_token_match.txt']
+                [indir + '/node_token_match.txt'],
+                rgi_dir=os.path.join(indir, 'rgi_train')
             )
             analyze_attention_matrix_network_optimize_iterate_shap.obtain_important_tokens(
                 train_at3,
@@ -698,7 +700,8 @@ def main():
             'graph_train',
             indir + '/strains_train_sentence_fs_shap.txt',
             pair_snv,
-            [indir + '/node_token_match.txt']
+            [indir + '/node_token_match.txt'],
+            rgi_dir=os.path.join(indir, 'rgi_train')
         )
         analyze_attention_matrix_network_optimize_iterate_shap.obtain_important_tokens(
             train_at3,
@@ -726,7 +729,8 @@ def main():
                 'graph_test',
                 indir + '/strains_train_sentence_fs_shap.txt',
                 pair_snv,
-                [indir + '/node_token_match.txt']
+                [indir + '/node_token_match.txt'],
+                rgi_dir=os.path.join(indir, 'rgi_train')
             )
             analyze_attention_matrix_network_optimize_iterate_shap.obtain_important_tokens(
                 test_at3,

--- a/library/analyze_attention_matrix_network_optimize_iterate_shap.py
+++ b/library/analyze_attention_matrix_network_optimize_iterate_shap.py
@@ -125,18 +125,19 @@ def stat_sent_count(sentence_file):
                 lf(s,dnc)
     return dpc,dnc
 
-def check_top10_attn(odir, dg, pre, shap_top, dc, dcs, dcn, map_dict=None):
+def check_top10_attn(odir, dg, pre, shap_top, dc, dcs, dcn, map_dict=None, rgi_map=None):
     d=nx.to_dict_of_dicts(dg)
     o=open(odir+'/'+pre+'_tokens_top_raw.txt','w+')
     o2=open(odir+'/'+pre+'_tokens_top_norm.txt','w+')
     o3=open(odir+'/'+pre+'_tokens_top_norm_sent.txt','w+')
     o4=open(odir+'/'+pre+'_tokens_top_norm_sent_m10_new.txt','w+')
     o5=open(odir+'/'+pre+'_tokens_top_norm_sent_m50_new.txt','w+')
-    o.write('ID\tShap_token_ID\tImportant_token\tFeature\tAttention_weight\n')
-    o2.write('ID\tShap_token_ID\tImportant_token\tFeature\tAttention_weight\n')
-    o3.write('ID\tShap_token_ID\tImportant_token\tFeature\tAttention_weight\n')
-    o4.write('ID\tShap_token_ID\tImportant_token\tFeature\tAttention_weight\n')
-    o5.write('ID\tShap_token_ID\tImportant_token\tFeature\tAttention_weight\n')
+    extra = ''
+    if rgi_map:
+        extra = '\tAMR_Gene_Family'
+    header = 'ID\tShap_token_ID\tImportant_token\tFeature' + extra + '\tAttention_weight\n'
+    for fh in (o, o2, o3, o4, o5):
+        fh.write(header)
     c=1
     c2=1
     c3=1
@@ -167,29 +168,34 @@ def check_top10_attn(odir, dg, pre, shap_top, dc, dcs, dcn, map_dict=None):
         res=sorted(tem.items(), key = lambda kv:(kv[1], kv[0]),reverse=True)
         for r in res[:10]:
             feat = utils.token_to_feature(r[0], map_dict)
-            o.write(f"{c}\t{s}\t{r[0]}\t{feat}\t{r[1]}\n")
+            amr = rgi_map.get(feat, 'NA') if rgi_map else 'NA'
+            o.write(f"{c}\t{s}\t{r[0]}\t{feat}\t{amr}\t{r[1]}\n")
             c+=1
         res2=sorted(tem2.items(), key = lambda kv:(kv[1], kv[0]),reverse=True)
 
         for r in res2[:10]:
             feat = utils.token_to_feature(r[0], map_dict)
-            o2.write(f"{c2}\t{s}\t{r[0]}\t{feat}\t{r[1]}\n")
+            amr = rgi_map.get(feat, 'NA') if rgi_map else 'NA'
+            o2.write(f"{c2}\t{s}\t{r[0]}\t{feat}\t{amr}\t{r[1]}\n")
             c2+=1
 
         res3=sorted(tem3.items(), key = lambda kv:(kv[1], kv[0]),reverse=True)
         for r in res3[:10]:
             feat = utils.token_to_feature(r[0], map_dict)
-            o3.write(f"{c3}\t{s}\t{r[0]}\t{feat}\t{r[1]}\n")
+            amr = rgi_map.get(feat, 'NA') if rgi_map else 'NA'
+            o3.write(f"{c3}\t{s}\t{r[0]}\t{feat}\t{amr}\t{r[1]}\n")
             c3+=1
         res4=sorted(tem4.items(), key = lambda kv:(kv[1], kv[0]),reverse=True)
         for r in res4[:10]:
             feat = utils.token_to_feature(r[0], map_dict)
-            o4.write(f"{c4}\t{s}\t{r[0]}\t{feat}\t{r[1]}\n")
+            amr = rgi_map.get(feat, 'NA') if rgi_map else 'NA'
+            o4.write(f"{c4}\t{s}\t{r[0]}\t{feat}\t{amr}\t{r[1]}\n")
             c4+=1
         res5=sorted(tem5.items(), key = lambda kv:(kv[1], kv[0]),reverse=True)
         for r in res5[:10]:
             feat = utils.token_to_feature(r[0], map_dict)
-            o5.write(f"{c5}\t{s}\t{r[0]}\t{feat}\t{r[1]}\n")
+            amr = rgi_map.get(feat, 'NA') if rgi_map else 'NA'
+            o5.write(f"{c5}\t{s}\t{r[0]}\t{feat}\t{amr}\t{r[1]}\n")
             c5+=1
 
     
@@ -435,7 +441,7 @@ def scan_graphs(out,g,pre):
 
     
 
-def obtain_important_tokens(matrix, sentence_file, odir, pre, shap_top_file, shap_pair_file=None, map_files=None):
+def obtain_important_tokens(matrix, sentence_file, odir, pre, shap_top_file, shap_pair_file=None, map_files=None, rgi_dir=None):
     '''
     f=open(sentence_file,'r')
     sentence_new_file=uuid.uuid1().hex+'.txt'
@@ -476,6 +482,7 @@ def obtain_important_tokens(matrix, sentence_file, odir, pre, shap_top_file, sha
             pair_scores[(int(p[0]), int(p[1]))] = float(p[2])
         fp2.close()
     map_dict = utils.load_token_mappings(map_files)
+    rgi_map = utils.load_rgi_annotations(rgi_dir)
     #exit()
     f=open(sentence_file,'r')
     line=f.readline()
@@ -566,8 +573,8 @@ def obtain_important_tokens(matrix, sentence_file, odir, pre, shap_top_file, sha
     graph_dir = os.path.join(odir, 'graphs')
     os.makedirs(token_dir, exist_ok=True)
     os.makedirs(graph_dir, exist_ok=True)
-    check_top10_attn(token_dir, dgp, pre + '_positive', shap_top, dpc, dpcs, dpc_sc, map_dict)
-    check_top10_attn(token_dir, dgn, pre + '_negative', shap_top, dnc, dpns, dnc_sc, map_dict)
+    check_top10_attn(token_dir, dgp, pre + '_positive', shap_top, dpc, dpcs, dpc_sc, map_dict, rgi_map)
+    check_top10_attn(token_dir, dgn, pre + '_negative', shap_top, dnc, dpns, dnc_sc, map_dict, rgi_map)
 
     scan_graphs(graph_dir, dgp, pre+'_positive')
     scan_graphs(graph_dir, dgn, pre+'_negative')

--- a/library/utils.py
+++ b/library/utils.py
@@ -29,3 +29,30 @@ def load_token_mappings(files):
 def token_to_feature(token_id, mapping):
     """Return human readable feature for token_id if available."""
     return mapping.get(str(token_id), str(token_id))
+
+
+def load_rgi_annotations(rgi_dir):
+    """Parse RGI tabular outputs and map ARO IDs to AMR Gene Family."""
+    info = {}
+    if not rgi_dir or not os.path.isdir(rgi_dir):
+        return info
+    for fname in os.listdir(rgi_dir):
+        if not fname.endswith('.txt'):
+            continue
+        path = os.path.join(rgi_dir, fname)
+        with open(path, 'r') as f:
+            header = f.readline().strip().split('\t')
+            header = [h.replace(' ', '_') for h in header]
+            idx = {h: i for i, h in enumerate(header)}
+            aro_i = idx.get('ARO')
+            if aro_i is None:
+                continue
+            gf_i = idx.get('AMR_Gene_Family')
+            for line in f:
+                parts = line.strip().split('\t')
+                if len(parts) <= aro_i:
+                    continue
+                aro = parts[aro_i]
+                gf = parts[gf_i] if gf_i is not None and gf_i < len(parts) else 'NA'
+                info[aro] = gf
+    return info


### PR DESCRIPTION
## Summary
- Run Prodigal/RGI in parallel in the test build script with a new `--threads` option.
- Parse `rgi_train` outputs to map ARO IDs to AMR gene families.
- Augment SNV SHAP tables and attention-token reports with AMR gene family annotations.
- Store SHAP feature files for test data in a dedicated `shap` directory and measure their lengths consistently with training.
- Document new threading option and RGI-derived SNV annotations in the README.

## Testing
- `python -m py_compile library/analyze_attention_matrix_network_optimize_iterate_shap.py StrainAMR_build_test.py StrainAMR_model_train.py StrainAMR_model_predict.py library/shap_feature_select_withcls.py library/utils.py StrainAMR_build_train.py`


------
https://chatgpt.com/codex/tasks/task_e_689e234637748333865c26c4a31d9e4f