### PR TITLE
Add feature limit parameter to training pipeline

### DIFF
--- a/StrainAMR_build_train.py
+++ b/StrainAMR_build_train.py
@@ -322,7 +322,7 @@ def scan_length(odir):
     
 
 
-def run(ingenome,label,odir,drug,pc_c,snv_c,kmer_c,mfile,threads=1):
+def run(ingenome,label,odir,drug,pc_c,snv_c,kmer_c,mfile,threads=1,feature_limit=None):
     dr={}
     for filename in os.listdir(ingenome):
         #pre=re.split('\.',filename)[0]
@@ -434,8 +434,18 @@ def run(ingenome,label,odir,drug,pc_c,snv_c,kmer_c,mfile,threads=1):
         if not kmer_c==1:
             run_ps(train,ingenome,label,drug,work_dir)
     
-        sef(work_dir+'/strains_train_sentence.txt',work_dir+'/feature_remain_graph.txt',work_dir+'/strains_train_sentence_fs.txt')
-        sef(work_dir+'/strains_train_pc_token.txt',work_dir+'/feature_remain_pc.txt',work_dir+'/strains_train_pc_token_fs.txt')
+        sef(
+            work_dir+'/strains_train_sentence.txt',
+            work_dir+'/feature_remain_graph.txt',
+            work_dir+'/strains_train_sentence_fs.txt',
+            feature_limit
+        )
+        sef(
+            work_dir+'/strains_train_pc_token.txt',
+            work_dir+'/feature_remain_pc.txt',
+            work_dir+'/strains_train_pc_token_fs.txt',
+            feature_limit
+        )
 
         #c+=1
     
@@ -475,6 +485,13 @@ def main():
     parser.add_argument('-s','--snv',dest='close_snv',type=int,help="If set to 1, then will skip snv tokens generation step. (Default: 0)",default=0)
     parser.add_argument('-k','--kmer',dest='close_kmer',type=int,help="If set to 1, then will skip k-mer tokens generation step. (Default:0)",default=0)
     parser.add_argument('-t','--threads',dest='threads',type=int,help="Number of parallel processes. (Default:1)",default=1)
+    parser.add_argument(
+        '--feature-limit',
+        dest='feature_limit',
+        type=int,
+        help="Maximum number of features to keep in feature_remain files (default: keep all).",
+        default=None
+    )
 
     #parser.add_argument('-m','--mfile',dest='map_file',type=str,help="The directory of the mapping file about the drug and its class.")
     parser.add_argument('-o','--outdir',dest='outdir',type=str,help="Output directory of results. (Default: StrainAMR_res)")
@@ -494,7 +511,10 @@ def main():
 
     #run('/computenodes/node35/team3/herui/AMR_data/Phenotype_Seeker_data/Ref_Genome','cdi_label.txt','Cdi_3fold','azithromycin','drug_to_class.txt')
     threads=args.threads
-    run(infile,lab_file,out,drug,pc_c,snv_c,kmer_c,mfile,threads)
+    feature_limit=args.feature_limit
+    if feature_limit is not None and feature_limit <= 0:
+        feature_limit=None
+    run(infile,lab_file,out,drug,pc_c,snv_c,kmer_c,mfile,threads,feature_limit)
 
 if __name__=="__main__":
     sys.exit(main())

--- a/feature_selection_sp.py
+++ b/feature_selection_sp.py
@@ -28,7 +28,7 @@ def scan_token(infile,ofile,d):
             o.write(ele[0]+'\t'+ele[1]+'\t'+str(len(tem))+'\t'+','.join(tem)+'\n')
     
 
-def sef(infile,ofile,ofile2):
+def sef(infile,ofile,ofile2,max_features=None):
     f=open(infile,'r')
     line=f.readline()
     d={} # strain -> token_id -> frequency
@@ -83,6 +83,8 @@ def sef(infile,ofile,ofile2):
         #c+=1
         #exit()
     res=sorted(dr.items(), key = lambda kv:(kv[1], kv[0]))
+    if max_features is not None and max_features > 0:
+        res=res[:max_features]
     dused={}
     for r in res:
         o.write(str(c)+'\t'+di[r[0]])


### PR DESCRIPTION
## Summary
- add an optional --feature-limit argument to StrainAMR_build_train so users can cap the retained features
- update feature selection helper to enforce the requested maximum when producing feature_remain outputs

## Testing
- python -m compileall StrainAMR_build_train.py feature_selection_sp.py

------
https://chatgpt.com/codex/tasks/task_e_68dec8ad6d308333a3fe185e4fbee493