### PR TITLE
Separate feature and sentence truncation controls

### DIFF
--- a/StrainAMR_build_test.py
+++ b/StrainAMR_build_test.py
@@ -290,16 +290,26 @@ def cal_len(infile1,infile2):
         line=f.readline().strip()
         if not line:break
         ele=line.split('\t')
-        if int(ele[-2])>ms:
-            ms=int(ele[-2])
+        tokens_field = ele[-1].strip() if ele else ''
+        if tokens_field:
+            token_count = len(tokens_field.split(','))
+        else:
+            token_count = 0
+        if token_count>ms:
+            ms=token_count
     f=open(infile2,'r')
     line=f.readline()
     while True:
         line=f.readline().strip()
         if not line:break
         ele=line.split('\t')
-        if int(ele[-2])>ms:
-            ms=int(ele[-2])
+        tokens_field = ele[-1].strip() if ele else ''
+        if tokens_field:
+            token_count = len(tokens_field.split(','))
+        else:
+            token_count = 0
+        if token_count>ms:
+            ms=token_count
     return ms
 
 def scan_length(odir):
@@ -315,7 +325,7 @@ def scan_length(odir):
 
 
 #def run(ingenome,label,odir,drug,mfile,intest,label2):
-def run(intest,label2,odir,drug,pc_c,snv_c,kmer_c,mfile,threads=1):
+def run(intest,label2,odir,drug,pc_c,snv_c,kmer_c,mfile,threads=1,feature_limit=None,sentence_limit=None):
     label=odir+'/train_label.txt'
     shap_dir = odir + '/shap'
     build_dir(shap_dir)
@@ -420,12 +430,40 @@ def run(intest,label2,odir,drug,pc_c,snv_c,kmer_c,mfile,threads=1):
         
         #train=x[train_idx]
         #val=x[val_idx]
-        sef_test(work_dir+'/strains_test_sentence.txt',work_dir+'/feature_remain_graph.txt',work_dir+'/strains_test_sentence_fs.txt')
-        sef_test(work_dir+'/strains_test_pc_token.txt',work_dir+'/feature_remain_pc.txt',work_dir+'/strains_test_pc_token_fs.txt')
+        sef_test(
+            work_dir+'/strains_test_sentence.txt',
+            work_dir+'/feature_remain_graph.txt',
+            work_dir+'/strains_test_sentence_fs.txt',
+            feature_limit,
+            sentence_limit
+        )
+        sef_test(
+            work_dir+'/strains_test_pc_token.txt',
+            work_dir+'/feature_remain_pc.txt',
+            work_dir+'/strains_test_pc_token_fs.txt',
+            feature_limit,
+            sentence_limit
+        )
         ### For shap
-        sef_test(work_dir+'/strains_test_sentence_fs.txt',shap_dir+'/strains_train_sentence_fs_shap_rmf.txt',shap_dir+'/strains_test_sentence_fs_shap_filter.txt')
-        sef_test(work_dir+'/strains_test_pc_token_fs.txt',shap_dir+'/strains_train_pc_token_fs_shap_rmf.txt',shap_dir+'/strains_test_pc_token_fs_shap_filter.txt')
-        sef_test(work_dir+'/strains_test_kmer_token.txt',shap_dir+'/strains_train_kmer_token_shap_rmf.txt',shap_dir+'/strains_test_kmer_token_shap_filter.txt')
+        sef_test(
+            work_dir+'/strains_test_sentence_fs.txt',
+            shap_dir+'/strains_train_sentence_fs_shap_rmf.txt',
+            shap_dir+'/strains_test_sentence_fs_shap_filter.txt',
+            None,
+            sentence_limit
+        )
+        sef_test(
+            work_dir+'/strains_test_pc_token_fs.txt',
+            shap_dir+'/strains_train_pc_token_fs_shap_rmf.txt',
+            shap_dir+'/strains_test_pc_token_fs_shap_filter.txt',
+            None,
+            sentence_limit
+        )
+        sef_test(
+            work_dir+'/strains_test_kmer_token.txt',
+            shap_dir+'/strains_train_kmer_token_shap_rmf.txt',
+            shap_dir+'/strains_test_kmer_token_shap_filter.txt'
+        )
 
         #c+=1
     scan_length(odir)
@@ -445,6 +483,20 @@ def main():
     parser.add_argument('-k','--kmer',dest='close_kmer',type=int,help="If set to 1, then will skip k-mer tokens generation step. (Default:0)",default=0)
     parser.add_argument('-o','--outdir',dest='outdir',type=str,help="Output directory of results. (Note: The output directory of your input test data must match the out directory of your training data.)")
     parser.add_argument('-t','--threads',dest='threads',type=int,help="Number of parallel processes. (Default:1)",default=1)
+    parser.add_argument(
+        '--feature-limit',
+        dest='feature_limit',
+        type=int,
+        help="Maximum number of features to keep when filtering with feature_remain files (default: keep all).",
+        default=None
+    )
+    parser.add_argument(
+        '--sentence-limit',
+        dest='sentence_limit',
+        type=int,
+        help="Maximum number of tokens per strain in *_sentence_fs.txt outputs (default: keep all).",
+        default=None
+    )
     args=parser.parse_args()
     infile=args.input_file
     lab_file=args.lab_file
@@ -458,7 +510,13 @@ def main():
     if not out:
         print('Please provide the output directoy that matches the out directory of your training data!')
         exit()
-    run(infile,lab_file,out,drug,pc_c,snv_c,kmer_c,mfile,threads)
+    feature_limit=args.feature_limit
+    if feature_limit is not None and feature_limit <= 0:
+        feature_limit=None
+    sentence_limit=args.sentence_limit
+    if sentence_limit is not None and sentence_limit <= 0:
+        sentence_limit=None
+    run(infile,lab_file,out,drug,pc_c,snv_c,kmer_c,mfile,threads,feature_limit,sentence_limit)
 
 if __name__=="__main__":
     sys.exit(main())

--- a/StrainAMR_build_train.py
+++ b/StrainAMR_build_train.py
@@ -296,8 +296,13 @@ def cal_len(infile1):
         line=f.readline().strip()
         if not line:break
         ele=line.split('\t')
-        if int(ele[-2])>ms:
-            ms=int(ele[-2])
+        tokens_field = ele[-1].strip() if ele else ''
+        if tokens_field:
+            token_count = len(tokens_field.split(','))
+        else:
+            token_count = 0
+        if token_count>ms:
+            ms=token_count
     '''
     f=open(infile2,'r')
     line=f.readline()
@@ -322,7 +327,7 @@ def scan_length(odir):
     
 
 
-def run(ingenome,label,odir,drug,pc_c,snv_c,kmer_c,mfile,threads=1):
+def run(ingenome,label,odir,drug,pc_c,snv_c,kmer_c,mfile,threads=1,feature_limit=None,sentence_limit=None):
     dr={}
     for filename in os.listdir(ingenome):
         #pre=re.split('\.',filename)[0]
@@ -434,8 +439,20 @@ def run(ingenome,label,odir,drug,pc_c,snv_c,kmer_c,mfile,threads=1):
         if not kmer_c==1:
             run_ps(train,ingenome,label,drug,work_dir)
     
-        sef(work_dir+'/strains_train_sentence.txt',work_dir+'/feature_remain_graph.txt',work_dir+'/strains_train_sentence_fs.txt')
-        sef(work_dir+'/strains_train_pc_token.txt',work_dir+'/feature_remain_pc.txt',work_dir+'/strains_train_pc_token_fs.txt')
+        sef(
+            work_dir+'/strains_train_sentence.txt',
+            work_dir+'/feature_remain_graph.txt',
+            work_dir+'/strains_train_sentence_fs.txt',
+            feature_limit,
+            sentence_limit
+        )
+        sef(
+            work_dir+'/strains_train_pc_token.txt',
+            work_dir+'/feature_remain_pc.txt',
+            work_dir+'/strains_train_pc_token_fs.txt',
+            feature_limit,
+            sentence_limit
+        )
 
         #c+=1
     
@@ -475,6 +492,20 @@ def main():
     parser.add_argument('-s','--snv',dest='close_snv',type=int,help="If set to 1, then will skip snv tokens generation step. (Default: 0)",default=0)
     parser.add_argument('-k','--kmer',dest='close_kmer',type=int,help="If set to 1, then will skip k-mer tokens generation step. (Default:0)",default=0)
     parser.add_argument('-t','--threads',dest='threads',type=int,help="Number of parallel processes. (Default:1)",default=1)
+    parser.add_argument(
+        '--feature-limit',
+        dest='feature_limit',
+        type=int,
+        help="Maximum number of features to keep in feature_remain files (default: keep all).",
+        default=None
+    )
+    parser.add_argument(
+        '--sentence-limit',
+        dest='sentence_limit',
+        type=int,
+        help="Maximum number of tokens per strain in *_sentence_fs.txt outputs (default: keep all).",
+        default=None
+    )
 
     #parser.add_argument('-m','--mfile',dest='map_file',type=str,help="The directory of the mapping file about the drug and its class.")
     parser.add_argument('-o','--outdir',dest='outdir',type=str,help="Output directory of results. (Default: StrainAMR_res)")
@@ -494,7 +525,13 @@ def main():
 
     #run('/computenodes/node35/team3/herui/AMR_data/Phenotype_Seeker_data/Ref_Genome','cdi_label.txt','Cdi_3fold','azithromycin','drug_to_class.txt')
     threads=args.threads
-    run(infile,lab_file,out,drug,pc_c,snv_c,kmer_c,mfile,threads)
+    feature_limit=args.feature_limit
+    if feature_limit is not None and feature_limit <= 0:
+        feature_limit=None
+    sentence_limit=args.sentence_limit
+    if sentence_limit is not None and sentence_limit <= 0:
+        sentence_limit=None
+    run(infile,lab_file,out,drug,pc_c,snv_c,kmer_c,mfile,threads,feature_limit,sentence_limit)
 
 if __name__=="__main__":
     sys.exit(main())

--- a/cal_length_fs.py
+++ b/cal_length_fs.py
@@ -248,8 +248,13 @@ def cal_len(infile1):
         line=f.readline().strip()
         if not line:break
         ele=line.split('\t')
-        if int(ele[-2])>ms:
-            ms=int(ele[-2])
+        tokens_field = ele[-1].strip() if ele else ''
+        if tokens_field:
+            token_count = len(tokens_field.split(','))
+        else:
+            token_count = 0
+        if token_count>ms:
+            ms=token_count
     '''
     f=open(infile2,'r')
     line=f.readline()

--- a/cal_length_test_fs.py
+++ b/cal_length_test_fs.py
@@ -248,16 +248,26 @@ def cal_len(infile1,infile2):
         line=f.readline().strip()
         if not line:break
         ele=line.split('\t')
-        if int(ele[-2])>ms:
-            ms=int(ele[-2])
+        tokens_field = ele[-1].strip() if ele else ''
+        if tokens_field:
+            token_count = len(tokens_field.split(','))
+        else:
+            token_count = 0
+        if token_count>ms:
+            ms=token_count
     f=open(infile2,'r')
     line=f.readline()
     while True:
         line=f.readline().strip()
         if not line:break
         ele=line.split('\t')
-        if int(ele[-2])>ms:
-            ms=int(ele[-2])
+        tokens_field = ele[-1].strip() if ele else ''
+        if tokens_field:
+            token_count = len(tokens_field.split(','))
+        else:
+            token_count = 0
+        if token_count>ms:
+            ms=token_count
     return ms
 
 def scan_length_fs(odir):

--- a/feature_selection_sp.py
+++ b/feature_selection_sp.py
@@ -4,7 +4,7 @@ import numpy as np
 from sklearn.feature_selection import chi2
 
 
-def scan_token(infile,ofile,d):
+def scan_token(infile,ofile,d,token_priority=None,max_tokens=None):
     o=open(ofile,'w+')
     f=open(infile,'r')
     line=f.readline().strip()
@@ -18,17 +18,42 @@ def scan_token(infile,ofile,d):
             o.write(line+'\n')
             continue
         tem=[]
-        for t in tk:
-            if t=='0':continue
+        for idx,t in enumerate(tk):
+            if t=='0':
+                continue
             if t in d:
-                tem.append(t)
-        if len(tem)==0:
-            o.write(ele[0]+'\t'+ele[1]+'\t'+str(len(tem))+'\t0\n')
+                tem.append((idx,t))
+        selected=tem
+        if max_tokens is not None and max_tokens>0 and len(tem)>max_tokens:
+            decorated=[]
+            default_rank=len(token_priority) if token_priority else 0
+            for original_idx,t in tem:
+                rank=default_rank+original_idx
+                if token_priority and t in token_priority:
+                    rank=token_priority[t]
+                decorated.append((rank,original_idx,t))
+            decorated.sort()
+            selected=[(orig_idx,tok) for _,orig_idx,tok in decorated[:max_tokens]]
+        if not selected:
+            kept_indices=set()
         else:
-            o.write(ele[0]+'\t'+ele[1]+'\t'+str(len(tem))+'\t'+','.join(tem)+'\n')
+            selected.sort(key=lambda x:x[0])
+            kept_indices={idx for idx,_ in selected}
+        tokens_out=[]
+        for idx,t in enumerate(tk):
+            if t=='0':
+                if not tokens_out or tokens_out[-1] != '0':
+                    tokens_out.append('0')
+                continue
+            if idx in kept_indices:
+                tokens_out.append(t)
+        if len(tokens_out)==0:
+            tokens_out=['0']
+        non_zero_count=sum(1 for t in tokens_out if t!='0')
+        o.write(ele[0]+'\t'+ele[1]+'\t'+str(non_zero_count)+'\t'+','.join(tokens_out)+'\n')
     
 
-def sef(infile,ofile,ofile2):
+def sef(infile,ofile,ofile2,max_features=None,max_tokens_per_sentence=None):
     f=open(infile,'r')
     line=f.readline()
     d={} # strain -> token_id -> frequency
@@ -83,15 +108,23 @@ def sef(infile,ofile,ofile2):
         #c+=1
         #exit()
     res=sorted(dr.items(), key = lambda kv:(kv[1], kv[0]))
+    if max_features is not None and max_features > 0:
+        res=res[:max_features]
     dused={}
+    ordered_features=[r[0] for r in res]
     for r in res:
         o.write(str(c)+'\t'+di[r[0]])
         dused[r[0]]=''
         c+=1
     if len(res)==0:
         dused=all_t
+        ordered_features=sorted(all_t.keys())
 
-    scan_token(infile,ofile2,dused)
+    token_priority={}
+    for idx,token in enumerate(ordered_features):
+        token_priority[token]=idx
+
+    scan_token(infile,ofile2,dused,token_priority if token_priority else None,max_tokens_per_sentence)
     '''
     o2=open(ofile2,'w+')
     f2=open(infile,'r')

--- a/library/feature_selection_sp_test.py
+++ b/library/feature_selection_sp_test.py
@@ -4,7 +4,7 @@ import numpy as np
 from sklearn.feature_selection import chi2
 
 
-def scan_token(infile,ofile,d):
+def scan_token(infile,ofile,d,token_priority=None,max_tokens=None):
     o=open(ofile,'w+')
     f=open(infile,'r')
     line=f.readline().strip()
@@ -18,19 +18,42 @@ def scan_token(infile,ofile,d):
             o.write(line+'\n')
             continue
         tem=[]
-        for t in tk:
+        for idx,t in enumerate(tk):
             if t=='0':
-                tem.append(t)
                 continue
             if t in d:
-                tem.append(t)
-        if len(tem)==0:
-            o.write(ele[0]+'\t'+ele[1]+'\t'+str(len(tem))+'\t0\n')
+                tem.append((idx,t))
+        selected=tem
+        if max_tokens is not None and max_tokens>0 and len(tem)>max_tokens:
+            decorated=[]
+            default_rank=len(token_priority) if token_priority else 0
+            for original_idx,t in tem:
+                rank=default_rank+original_idx
+                if token_priority and t in token_priority:
+                    rank=token_priority[t]
+                decorated.append((rank,original_idx,t))
+            decorated.sort()
+            selected=[(orig_idx,tok) for _,orig_idx,tok in decorated[:max_tokens]]
+        if not selected:
+            kept_indices=set()
         else:
-            o.write(ele[0]+'\t'+ele[1]+'\t'+str(len(tem))+'\t'+','.join(tem)+'\n')
+            selected.sort(key=lambda x:x[0])
+            kept_indices={idx for idx,_ in selected}
+        tokens_out=[]
+        for idx,t in enumerate(tk):
+            if t=='0':
+                if not tokens_out or tokens_out[-1] != '0':
+                    tokens_out.append('0')
+                continue
+            if idx in kept_indices:
+                tokens_out.append(t)
+        if len(tokens_out)==0:
+            tokens_out=['0']
+        non_zero_count=sum(1 for t in tokens_out if t!='0')
+        o.write(ele[0]+'\t'+ele[1]+'\t'+str(non_zero_count)+'\t'+','.join(tokens_out)+'\n')
     
 
-def sef_test(infile2,infile,ofile):
+def sef_test(infile2,infile,ofile,max_features=None,max_tokens_per_sentence=None):
     '''
     f=open(infile,'r')
     line=f.readline()
@@ -85,16 +108,27 @@ def sef_test(infile2,infile,ofile):
     res=sorted(dr.items(), key = lambda kv:(kv[1], kv[0]))
     '''
     dused={}
+    ordered_features=[]
 
     f=open(infile,'r')
     line=f.readline()
+    count=0
     while True:
         line=f.readline().strip()
         if not line:break
         ele=line.split('\t')
-        dused[str(ele[1])]=''
+        feature_id=str(ele[1])
+        dused[feature_id]=''
+        ordered_features.append(feature_id)
+        count+=1
+        if max_features is not None and max_features>0 and count>=max_features:
+            break
 
-    scan_token(infile2,ofile,dused)
+    token_priority={}
+    for idx,token in enumerate(ordered_features):
+        token_priority[token]=idx
+
+    scan_token(infile2,ofile,dused,token_priority if token_priority else None,max_tokens_per_sentence)
     '''
     o2=open(ofile2,'w+')
     f2=open(infile,'r')


### PR DESCRIPTION
## Summary
- add independent --feature-limit and --sentence-limit options to the training and test builders and propagate the feature cap into their feature-selection calls
- refine feature-selection helpers to truncate feature_remain outputs separately from per-sample token limits while preserving zero separators and collapsing duplicates
- mirror the updated filtering and optional feature cap logic in the test utilities, including the copy under library/
- update longest-length scanners in the train/test builders and feature-selected workflows to count comma-delimited zero separators so allocation matches the serialized tokens

## Testing
- python -m compileall StrainAMR_build_train.py StrainAMR_build_test.py cal_length_fs.py cal_length_test_fs.py

------
https://chatgpt.com/codex/tasks/task_e_68dec8ad6d308333a3fe185e4fbee493