### PR TITLE
Propagate feature metadata into interpretability exports

### DIFF
--- a/StrainAMR_build_train.py
+++ b/StrainAMR_build_train.py
@@ -444,14 +444,17 @@ def run(ingenome,label,odir,drug,pc_c,snv_c,kmer_c,mfile,threads=1,feature_limit
             work_dir+'/feature_remain_graph.txt',
             work_dir+'/strains_train_sentence_fs.txt',
             feature_limit,
-            sentence_limit
+            sentence_limit,
+            mapping_files=[work_dir+'/node_token_match.txt'],
+            rgi_dir=work_dir+'/rgi_train'
         )
         sef(
             work_dir+'/strains_train_pc_token.txt',
             work_dir+'/feature_remain_pc.txt',
             work_dir+'/strains_train_pc_token_fs.txt',
             feature_limit,
-            sentence_limit
+            sentence_limit,
+            mapping_files=[work_dir+'/pc_matches.txt']
         )
 
         #c+=1

--- a/StrainAMR_model_predict.py
+++ b/StrainAMR_model_predict.py
@@ -556,6 +556,15 @@ def main():
                 feature_tensors.append(torch.from_numpy(x_val2))
             if fnum == 3:
                 feature_tensors.append(torch.from_numpy(x_val3))
+
+            annotation_file_map = {
+                'snv': [os.path.join(indir, 'feature_remain_graph.txt')],
+                'pc': [os.path.join(indir, 'feature_remain_pc.txt')],
+                'kmer': [os.path.join(indir, 'kmer_token_id.txt')],
+            }
+            relevant_annotations = {
+                label: annotation_file_map.get(label, []) for label in feature_labels
+            }
             try:
                 export_token_contributions(
                     model,
@@ -570,6 +579,7 @@ def main():
                     subset_sizes=(2, 3),
                     subset_sample_size=32,
                     sample_ids=sid_val,
+                    annotation_file_map=relevant_annotations,
                 )
                 print('Saved interpretability summaries for test predictions.', flush=True)
             except Exception as exc:

--- a/StrainAMR_model_train.py
+++ b/StrainAMR_model_train.py
@@ -624,6 +624,14 @@ def main():
         fallback = os.path.join(indir, filename)
         shap_file_map[key] = primary if os.path.exists(primary) else fallback
 
+    annotation_file_map = {
+        'snv': [os.path.join(indir, 'feature_remain_graph.txt')],
+        'pc': [os.path.join(indir, 'feature_remain_pc.txt')],
+        'kmer': [os.path.join(indir, 'kmer_token_id.txt')],
+    }
+
+    relevant_annotations = {label: annotation_file_map.get(label, []) for label in feature_labels}
+
     export_token_contributions(
         model,
         feature_arrays,
@@ -636,6 +644,7 @@ def main():
         top_k_pairs=20,
         subset_sizes=(2, 3),
         subset_sample_size=32,
+        annotation_file_map=relevant_annotations,
     )
 
 


### PR DESCRIPTION
## Summary
- enrich feature selection outputs with feature names and AMR family metadata sourced from token mappings and RGI annotations
- pass the enriched metadata through training and prediction workflows so interpretability exports can draw annotations without relying on SHAP tables
- update the token contribution exporter to merge metadata from feature_remain and k-mer mapping files alongside SHAP annotations

## Testing
- python -m compileall feature_selection_sp.py StrainAMR_model_train.py StrainAMR_model_predict.py library/token_contribution.py

------
https://chatgpt.com/codex/tasks/task_e_68e9671f4b7c8333921215e3e5b52573